### PR TITLE
Added information to @efficiency decorator

### DIFF
--- a/slippery/decorators.py
+++ b/slippery/decorators.py
@@ -82,7 +82,14 @@ def efficiency(func):
         finally:
             profiler.disable()
             stats = CustomStats(profiler, stream=sys.stdout)
+            args, kwargs = represent_params(args, kwargs)
             print('{b}'.format(b=o.BLUE_LINES), end='\n\n')
+            print(o.EFF_TEMPLATE.format(**{
+                'func': func.__name__,
+                'line': get_line(func),
+                'args': args,
+                'kwargs': kwargs
+            }))
             stats.print_stats()
             print('{b}'.format(b=o.BLUE_LINES), end='\n\n')
 

--- a/slippery/output.py
+++ b/slippery/output.py
@@ -48,3 +48,9 @@ DIS_TEMPLATE = """
 \033[92mPositional arguments    \033[0m: {args}
 \033[92mKeyword arguments\033[0m: {kwargs}
 """
+
+EFF_TEMPLATE = """
+\033[92mFunction\033[0m: \033[1m{func}\033[0m at line {line}.
+\033[92mPositional arguments    \033[0m: {args}
+\033[92mKeyword arguments\033[0m: {kwargs}
+"""


### PR DESCRIPTION
As a test, this looks somewhat as follows:
![screenshot from 2017-10-01 01-17-30](https://user-images.githubusercontent.com/10978108/31048925-79e89848-a646-11e7-9b9a-0e8fc27029a1.png)

Let me know if I should indent the output block further or any more changes required. 