### PR TITLE
Changed `get_module_name()` to return the full filename. 

### DIFF
--- a/slippery/utils.py
+++ b/slippery/utils.py
@@ -29,7 +29,7 @@ def get_line(fn):
 
 
 def get_module_name(fn):
-    return inspect.getmodule(fn).__file__[:-1]
+    return inspect.getmodule(fn).__file__.strip()
 
 
 def shortened(seq, max_len=10):


### PR DESCRIPTION
The old version would leave off the last character, e.g. `myfile.p` instead of `myfile.py`.