### PR TITLE
PEP8 changes

### DIFF
--- a/slippery/__init__.py
+++ b/slippery/__init__.py
@@ -1,2 +1,1 @@
 from slippery.decorators import *
-

--- a/slippery/colors.py
+++ b/slippery/colors.py
@@ -9,6 +9,7 @@ COLORS = {
     'cyan': CYAN,
 }
 
+
 def color_line(msg, clr):
     return '{}{}{}'.format(COLORS[clr], msg, RESET)
 

--- a/slippery/helpers.py
+++ b/slippery/helpers.py
@@ -56,11 +56,13 @@ class CustomStats(Stats):
         for func in self.top_level:
             print(indent, func_get_function_name(func), file=self.stream)
 
-        print(indent, color.green('{} function calls'.format(self.total_calls)),
-              end=' ', file=self.stream)
+        print(indent, color.green('{} function calls'.format(
+            self.total_calls)), end=' ', file=self.stream)
         if self.total_calls != self.prim_calls:
-            print("(%d primitive calls)" % self.prim_calls, end=' ', file=self.stream)
-        print("in \033[33m{:.8f} \033[92mseconds\033[0m.".format(self.total_tt), file=self.stream)
+            print("(%d primitive calls)" % self.prim_calls, end=' ',
+                  file=self.stream)
+        print("in \033[33m{:.8f} \033[92mseconds\033[0m.".format(
+            self.total_tt), file=self.stream)
         print(file=self.stream)
         width, list = self.get_print_list(amount)
         if list:

--- a/slippery/templates.py
+++ b/slippery/templates.py
@@ -39,11 +39,12 @@ class LinesPrinter(object):
 
 
 FUNC_HEADER_TEMPLATE = Template(BLUE_LINES + """
-${green}File${reset}: {file} [line {line}]: 
+${green}File${reset}: {file} [line {line}]:
 ${green}Function${reset}: ${bold}{func}(${reset}{signature}${bold})${reset}
 ${green}Positional arguments${reset}: {args}
 ${green}Keyword arguments${reset}: {kwargs}
 """ + LINES).safe_substitute(**COLORS)
+
 
 def format_function_header(func, args, kwargs):
     args, kwargs = represent_params(args, kwargs)


### PR DESCRIPTION
Changes to abide by PEP8 religio... aham... rules.

Before the changes:
leonardo@slippery ◈ pycodestyle .
./slippery/__init__.py:2:1: W391 blank line at end of file
./slippery/colors.py:12:1: E302 expected 2 blank lines, found 1
./slippery/helpers.py:59:80: E501 line too long (80 > 79 characters)
./slippery/helpers.py:62:80: E501 line too long (86 > 79 characters)
./slippery/helpers.py:63:80: E501 line too long (98 > 79 characters)
./slippery/templates.py:42:44: W291 trailing whitespace
./slippery/templates.py:48:1: E302 expected 2 blank lines, found 1


After the changes:
leonardo@slippery ◈ pycodestyle .
leonardo@slippery ◈ 

I dont always agree with the 79 columns rules but since it's parameters i think it's ok to split it on multiple lines.

Feel free to disregard this PR if you dont mind. But you do, dont you?
![pep8](https://su27.github.io/python-intro/static/image/no-pep8-no-soup.jpg)